### PR TITLE
numpy.sliding_window_view in PeriodicCycleMiner

### DIFF
--- a/skmine/periodic/tests/test_cycles.py
+++ b/skmine/periodic/tests/test_cycles.py
@@ -5,7 +5,7 @@ from collections import Counter
 import datetime as dt
 
 from ..cycles import (
-    window_stack,
+    sliding_window_view,
     residual_length,
     cycle_length,
     get_table_dyn,
@@ -71,16 +71,16 @@ def triples():
 
 
 @pytest.mark.parametrize("k", [3, 5])
-def test_window_stack(minutes, k):
-    w = window_stack(minutes, width=k)
+def test_window_view(minutes, k):
+    w = sliding_window_view(minutes, k)
     assert w.shape == (len(minutes) - k + 1, k)
     np.testing.assert_array_equal(w[0], minutes[:k])
     np.testing.assert_array_equal(w[-1], minutes[-k:])
 
 
 def test_cycle_length_triples(minutes):
-    triples = window_stack(minutes)
-    inter = window_stack(np.diff(minutes), width=2)
+    triples = sliding_window_view(minutes, 3)
+    inter = sliding_window_view(np.diff(minutes), 2)
     delta_S = delta_S = minutes[-1] - minutes[0]
     L_a, L_r, L_p, L_tau, L_E = cycle_length(triples, inter, len(minutes), delta_S)
 

--- a/skmine/utils.py
+++ b/skmine/utils.py
@@ -5,6 +5,9 @@ utils functions
 import numpy as np
 import pandas as pd
 from sortedcontainers import SortedList
+from numpy.core.numeric import normalize_axis_tuple
+from numpy.core.overrides import array_function_dispatch
+from numpy.lib.stride_tricks import as_strided
 
 
 def _check_random_state(random_state):
@@ -179,3 +182,128 @@ def intersect2d(ar1, ar2, return_indices=True):
         y_ind = y_ind[xy_where]
         return ar1[x_ind], x_ind, y_ind
     return ar1[x_ind]
+
+
+def _sliding_window_view_dispatcher(x, window_shape, axis=None, *,
+                                    subok=None, writeable=None):
+    return (x,)
+
+
+@array_function_dispatch(_sliding_window_view_dispatcher)
+def sliding_window_view(x, window_shape, axis=None, *,
+                        subok=False, writeable=False):
+    """
+    COPIED from https://github.com/numpy/numpy/blob/v1.20.0/numpy/lib/stride_tricks.py#L122-L336
+
+    Create a sliding window view into the array with the given window shape.
+    Also known as rolling or moving window, the window slides across all
+    dimensions of the array and extracts subsets of the array at all window
+    positions.
+
+    Parameters
+    ----------
+    x : array_like
+        Array to create the sliding window view from.
+    window_shape : int or tuple of int
+        Size of window over each axis that takes part in the sliding window.
+        If `axis` is not present, must have same length as the number of input
+        array dimensions. Single integers `i` are treated as if they were the
+        tuple `(i,)`.
+    axis : int or tuple of int, optional
+        Axis or axes along which the sliding window is applied.
+        By default, the sliding window is applied to all axes and
+        `window_shape[i]` will refer to axis `i` of `x`.
+        If `axis` is given as a `tuple of int`, `window_shape[i]` will refer to
+        the axis `axis[i]` of `x`.
+        Single integers `i` are treated as if they were the tuple `(i,)`.
+    subok : bool, optional
+        If True, sub-classes will be passed-through, otherwise the returned
+        array will be forced to be a base-class array (default).
+    writeable : bool, optional
+        When true, allow writing to the returned view. The default is false,
+        as this should be used with caution: the returned view contains the
+        same memory location multiple times, so writing to one location will
+        cause others to change.
+    Returns
+    -------
+    view : ndarray
+        Sliding window view of the array. The sliding window dimensions are
+        inserted at the end, and the original dimensions are trimmed as
+        required by the size of the sliding window.
+        That is, ``view.shape = x_shape_trimmed + window_shape``, where
+        ``x_shape_trimmed`` is ``x.shape`` with every entry reduced by one less
+        than the corresponding window size.
+    See Also
+    --------
+    lib.stride_tricks.as_strided: A lower-level and less safe routine for
+        creating arbitrary views from custom shape and strides.
+    broadcast_to: broadcast an array to a given shape.
+    Notes
+    -----
+    For many applications using a sliding window view can be convenient, but
+    potentially very slow. Often specialized solutions exist, for example:
+    - `scipy.signal.fftconvolve`
+    - filtering functions in `scipy.ndimage`
+    - moving window functions provided by
+      `bottleneck <https://github.com/pydata/bottleneck>`_.
+    As a rough estimate, a sliding window approach with an input size of `N`
+    and a window size of `W` will scale as `O(N*W)` where frequently a special
+    algorithm can achieve `O(N)`. That means that the sliding window variant
+    for a window size of 100 can be a 100 times slower than a more specialized
+    version.
+    Nevertheless, for small window sizes, when no custom algorithm exists, or
+    as a prototyping and developing tool, this function can be a good solution.
+    Examples
+    --------
+   
+    >>> x = np.arange(6)
+    >>> x.shape
+    (6,)
+    >>> v = sliding_window_view(x, 3)
+    >>> v.shape
+    (4, 3)
+    >>> v
+    array([[0, 1, 2],
+           [1, 2, 3],
+           [2, 3, 4],
+           [3, 4, 5]])
+    >>> moving_average = v.mean(axis=-1)
+    >>> moving_average
+    array([1., 2., 3., 4.])
+    """
+    window_shape = (tuple(window_shape)
+                    if np.iterable(window_shape)
+                    else (window_shape,))
+    # first convert input to array, possibly keeping subclass
+    x = np.array(x, copy=False, subok=subok)
+
+    window_shape_array = np.array(window_shape)
+    if np.any(window_shape_array < 0):
+        raise ValueError('`window_shape` cannot contain negative values')
+
+    if axis is None:
+        axis = tuple(range(x.ndim))
+        if len(window_shape) != len(axis):
+            raise ValueError(f'Since axis is `None`, must provide '
+                             f'window_shape for all dimensions of `x`; '
+                             f'got {len(window_shape)} window_shape elements '
+                             f'and `x.ndim` is {x.ndim}.')
+    else:
+        axis = normalize_axis_tuple(axis, x.ndim, allow_duplicate=True)
+        if len(window_shape) != len(axis):
+            raise ValueError(f'Must provide matching length window_shape and '
+                             f'axis; got {len(window_shape)} window_shape '
+                             f'elements and {len(axis)} axes elements.')
+
+    out_strides = x.strides + tuple(x.strides[ax] for ax in axis)
+
+    # note: same axis can be windowed repeatedly
+    x_shape_trimmed = list(x.shape)
+    for ax, dim in zip(axis, window_shape):
+        if x_shape_trimmed[ax] < dim:
+            raise ValueError(
+                'window shape cannot be larger than input array shape')
+        x_shape_trimmed[ax] -= dim - 1
+    out_shape = tuple(x_shape_trimmed) + window_shape
+    return as_strided(x, strides=out_strides, shape=out_shape,
+                      subok=subok, writeable=writeable)


### PR DESCRIPTION
Copied function from numpy https://github.com/numpy/numpy/blob/v1.20.0/numpy/lib/stride_tricks.py#L122-L336

Which raises questions like : Should numpy 1.20.0 be a dependency of skmine ? knowing how big this release is this may be risky

TODO 
- [x] asv continuous, especially for `peakmem_*` functions which should be affected by using views instead of copies