### PR TITLE
Running tests on several python versions / display parameters in transform + documentation at the right place

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,8 @@
 name: linting
 on:
-  workflow_run:
-    workflows: ["tests"]
-    types: ["completed"]
+  push:
+    paths:
+      - skmine/**
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,7 @@ name: linting
 on:
   push:
     paths:
-      - master
+      - skmine/**
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,7 @@ name: linting
 on:
   push:
     paths:
-      - skmine/**
+      - master
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,12 +1,11 @@
 name: linting
 on:
-  push:
-    paths:
-      - skmine/**
+  workflow_run:
+    workflows: ["tests"]
+    types: ["completed"]
 jobs:
   run:
     runs-on: ubuntu-latest
-    needs: [tests]
     steps:
       - uses: actions/checkout@master
       - name: Setup Python

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    needs: [tests]
     steps:
       - uses: actions/checkout@master
       - name: Setup Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version:
-          - '3.x-3'
-          - '3.x-2'
-          - '3.x-1'
-          - '3.x'
+        python-version: [3.x, 3.$(shell expr x - 1)]
+
     steps:
       - uses: actions/checkout@master
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.x, 3.$(shell expr x - 1)]
-
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.x'
     steps:
       - uses: actions/checkout@master
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
         python-version:
           - 3.8
           - 3.9
-          - 3.10
           - 3.11
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
           - 3.11
     steps:
       - uses: actions/checkout@master
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@master
         with:
-          python-version: ${{matrix.python-version}}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version:
+          - 3.8
+          - 3.9
+          - 3.10
+          - 3.11
     steps:
       - uses: actions/checkout@master
       - name: Setup Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
-          - 3.8
-          - 3.9
+          - '3.8'
+          - '3.9'
           - '3.10'
-          - 3.11
+          - '3.11'
     steps:
       - uses: actions/checkout@master
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - '3.x-3'
+          - '3.x-2'
+          - '3.x-1'
           - '3.x'
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@master
         with:
-          python-version: 3.7
+          python-version: ${{matrix.python-version}}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          - '3.11'
+          - '3.x'
     steps:
       - uses: actions/checkout@master
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
         python-version:
           - 3.8
           - 3.9
+          - '3.10'
           - 3.11
     steps:
       - uses: actions/checkout@master

--- a/docs/tutorials/itemsets/LCM_on_chess.ipynb
+++ b/docs/tutorials/itemsets/LCM_on_chess.ipynb
@@ -17,7 +17,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This tutorial was tested with the following version of skmine : 0.0.9\n"
+      "This tutorial was tested with the following version of skmine : 0.0.10\n"
      ]
     }
    ],
@@ -99,8 +99,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 110 ms, sys: 46.7 ms, total: 156 ms\n",
-      "Wall time: 2.08 s\n"
+      "CPU times: user 45.4 ms, sys: 33.2 ms, total: 78.6 ms\n",
+      "Wall time: 1.56 s\n"
      ]
     }
    ],
@@ -386,7 +386,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "skmine",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -400,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13 (default, Mar 29 2022, 02:18:16) \n[GCC 7.5.0]"
+   "version": "3.11.1"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/tutorials/itemsets/SLIM.ipynb
+++ b/docs/tutorials/itemsets/SLIM.ipynb
@@ -22,7 +22,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "This tutorial was tested with the following version of skmine : 0.0.9\n"
+      "This tutorial was tested with the following version of skmine : 0.0.10\n"
      ]
     }
    ],
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -145,14 +145,14 @@
        "3         [butter]      1"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "slim = SLIM(pruning=True)\n",
-    "slim.fit(D).transform(D)"
+    "slim.fit_transform(D)"
    ]
   },
   {
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -180,7 +180,7 @@
        " ['jelly', 'bananas', 'cookies']]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -266,21 +266,14 @@
        "4          [butter]      1"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "SLIM().fit(D).transform(D)"
+    "SLIM().fit_transform(D)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -299,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.1"
   },
   "toc": {
    "base_numbering": 1,

--- a/skmine/__init__.py
+++ b/skmine/__init__.py
@@ -8,5 +8,5 @@ Pattern mining algorithms for the Python ecosystem
 # joblib currently disable logging inside delayed functions
 __author__ = """scikit-mine team"""
 __email__ = """skm-dev@inria.fr"""
-__version__ = "0.0.10"  # pylint: disable= undefined-variable, pointless-statement
+__version__ = "0.0.11"  # pylint: disable= undefined-variable, pointless-statement
 __credits__ = "Centre Inria de l'Université de Rennes"

--- a/skmine/base.py
+++ b/skmine/base.py
@@ -3,6 +3,7 @@
 
 import inspect
 from abc import ABC, abstractmethod
+from sklearn.base import TransformerMixin
 
 import numpy as np
 import pandas as pd
@@ -132,14 +133,24 @@ class DiscovererMixin:
             return self.fit(D, y=y).discover(**kwargs)
 
 
-class TransformerMixin:
+class TransformerMixin(TransformerMixin):
     """Base Mixin for transformers in scikit-mine"""
 
-    def fit_transform(self, X, y=None):
-        """fit on X and y, then transform X"""
-        return self.fit(X, y).transform(X)
+    def fit_transform(self, X, y=None, **tsf_params):
+        """
+        Override sklearn transformer method to apply optional parameters `tsf_params` on transform  and not to fit
+        Returns a transformed version of `X`: i.e. the fitted codetable
 
-    decision_function = None
+        Returns
+        -------
+        df_new : pandas.Dataframe
+            Codetable fitted from X data.
+        """
+
+        if y is None:
+            return self.fit(X).transform(X, **tsf_params)
+        else:
+            return self.fit(X, y).transform(X, **tsf_params)
 
 
 class MDLOptimizer(ABC):

--- a/skmine/itemsets/lcm.py
+++ b/skmine/itemsets/lcm.py
@@ -158,8 +158,8 @@ class LCM(TransformerMixin, BaseEstimator):
         lexicographic_order: bool, default=True
             Either the order of the items in each itemset is not ordered or the items are ordered lexicographically
 
-        max_length: int, default=-1 Maximum length of an itemset. By default, -1 means that LCM returns itemsets of
-        all lengths.
+        max_length: int, default=-1
+            Maximum length of an itemset. By default, -1 means that LCM returns itemsets of all lengths.
 
         out : str, default=None
             File where results are written. Discover return None. The 'out' option is usefull 

--- a/skmine/itemsets/lcm.py
+++ b/skmine/itemsets/lcm.py
@@ -80,7 +80,7 @@ class LCM(TransformerMixin, BaseEstimator):  # BaseMiner, DiscovererMixin): #Tra
 
     def _more_tags(self):
         return {
-            "non_deterministic": True,  # default
+            "non_deterministic": True,
             "preserves_dtype": False,
             "no_validation": True,
         }

--- a/skmine/itemsets/lcm.py
+++ b/skmine/itemsets/lcm.py
@@ -80,26 +80,9 @@ class LCM(TransformerMixin, BaseEstimator):  # BaseMiner, DiscovererMixin): #Tra
 
     def _more_tags(self):
         return {
-            # "non_deterministic": False,  # default
-            # "requires_positive_X": True,
-            # "requires_positive_y": False,  # default
-            # "X_types": ['2darray'], 2dlabels # ["categorical"],  # default
-            # # "poor_score": False,  # default
             "non_deterministic": True,  # default
             "preserves_dtype": False,
             "no_validation": True,
-            # "multioutput": False,  # default
-            # "allow_nan": False,  # default
-            # "stateless": False,  # default
-            # "multilabel": False,  # default
-            # "_skip_test": False,  # default
-            # "_xfail_checks": False, # default
-            # "multioutput_only": False,  # default
-            # "binary_only": False,  # default
-            # "requires_fit": True,  # default
-            # "preserves_dtype": [numpy.float64], # default   ## [pd.DataFrame, np.int],
-            # "requires_y": False, # default
-            # "pairwise": False,  # default
         }
 
     def fit(self, D, y=None, return_tids=False, lexicographic_order=True, max_length=-1, out=None):

--- a/skmine/itemsets/lcm.py
+++ b/skmine/itemsets/lcm.py
@@ -149,9 +149,8 @@ class LCM(TransformerMixin, BaseEstimator):  # BaseMiner, DiscovererMixin): #Tra
         Parameters
         ----------
         D : pd.Series or Iterable
-            The input transactional database
-            Where every entry contain singular items
-            Items must be both hashable and comparable
+            The input transactional database where every entry contain singular items
+            must be both hashable and comparable
 
         return_tids: bool, default=False
             Either to return transaction ids along with itemset.

--- a/skmine/itemsets/lcm.py
+++ b/skmine/itemsets/lcm.py
@@ -11,23 +11,24 @@ as described in `http://lig-membres.imag.fr/termier/HLCM/hlcm.pdf`
 #
 # License: BSD 3 clause
 
+import os
+import shutil
 from collections import defaultdict
 from itertools import takewhile
 
 import pandas as pd
-import os
-import shutil
 from joblib import Parallel, delayed
-from sortedcontainers import SortedDict
 from pyroaring import BitMap as Bitmap
+from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
+from sortedcontainers import SortedDict
+
+from skmine.base import TransformerMixin
 from ..utils import _check_min_supp
 from ..utils import filter_maximal
-from sklearn.base import BaseEstimator
-from skmine.base import TransformerMixin
 
 
-class LCM(TransformerMixin, BaseEstimator):  # BaseMiner, DiscovererMixin): #TransformerMixin, BaseEstimator) : :
+class LCM(TransformerMixin, BaseEstimator):
     """
     Linear time Closed item set Miner.
 
@@ -340,7 +341,7 @@ class LCMMax(LCM, TransformerMixin):
 
             for new_limit in candidates:
                 ids = self.item_to_tids_[new_limit]
-                if tids.intersection_cardinality(ids) >= self.min_supp:
+                if tids.intersection_cardinality(ids) >= self.min_supp_:
                     no_cand = False
                     # get new pattern and its associated tids
                     new_p_tids = (p_prime, tids.intersection(ids))

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -9,21 +9,19 @@ and https://eda.rg.cispa.io/pres/ida14-slimmer-poster.pdf
 #          Cyril Regan <cyril.regan@loria.fr>
 # License: BSD 3 clause
 
+import time
 from collections import Counter, defaultdict
 from functools import lru_cache, reduce
 from itertools import chain
 
 import numpy as np
 import pandas as pd
-import time
-
-from sortedcontainers import SortedDict
 from pyroaring import BitMap as Bitmap
-
-from sklearn.utils.validation import check_is_fitted
 from sklearn.base import BaseEstimator
-from skmine.base import TransformerMixin
+from sklearn.utils.validation import check_is_fitted
+from sortedcontainers import SortedDict
 
+from skmine.base import TransformerMixin
 from ..utils import _check_D, supervised_to_unsupervised
 
 
@@ -476,9 +474,8 @@ class SLIM(BaseEstimator, TransformerMixin):
 
         return pd.DataFrame(mat, columns=list(covers.keys()))
 
-
-    def transform(self, D, singletons=True, return_tids=False, lexicographic_order=True,
-                  drop_null_usage=True, return_dl=False, out=None):
+    def transform(self, D, singletons=True, return_tids=False, lexicographic_order=True, drop_null_usage=True,
+                  return_dl=False, out=None):
         """Get a user-friendly copy of the codetable
 
         Parameters

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -159,7 +159,7 @@ class SLIM(BaseEstimator, TransformerMixin):
         else:
             return self.fit(X, y).transform(X, tsf_params)
 
-    def fit(self, X, y=None):  # -> self
+    def fit(self, X, y=None):
         """fit SLIM on a transactional dataset
 
         This generates new candidate patterns and add those which improve compression,

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -22,7 +22,6 @@ from pyroaring import BitMap as Bitmap
 
 from sklearn.utils.validation import check_is_fitted
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.preprocessing import MultiLabelBinarizer
 
 from ..utils import _check_D, supervised_to_unsupervised
 
@@ -142,10 +141,8 @@ class SLIM(BaseEstimator, TransformerMixin):
     def _more_tags(self):  # tags for sklearn check_estimators)
         return {
             "non_deterministic": True,  # default
-            # "X_types": ['2darray'],  # ["categorical"],  # default
             "no_validation": True,
             "preserves_dtype": False,
-            # "pairwise": True,
         }
 
     def fit_transform(self, X, y=None, **tsf_params):  # TODO refactor to TransformerMixin Custom ? for LCM, SLIM

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -574,7 +574,7 @@ class SLIM(BaseEstimator, TransformerMixin):
             return df
 
     def reconstruct(self) -> pd.Series:
-        """reconstruct the original data from the current `self.codetable_`. This is possible because SLIM is a
+        """Reconstruct the original data from the current `self.codetable_`. This is possible because SLIM is a
         lossless algorithm .
 
         Example

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -575,7 +575,7 @@ class SLIM(BaseEstimator, TransformerMixin):
 
     def reconstruct(self) -> pd.Series:
         """Reconstruct the original data from the current `self.codetable_`. This is possible because SLIM is a
-        lossless algorithm .
+        lossless algorithm.
 
         Example
         -------

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -138,7 +138,7 @@ class SLIM(BaseEstimator, TransformerMixin):
         self.max_time = max_time
         self.items = items
 
-    def _more_tags(self):  # tags for sklearn check_estimators)
+    def _more_tags(self):
         return {
             "no_validation": True,
             "preserves_dtype": False,

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -463,7 +463,6 @@ class SLIM(BaseEstimator, TransformerMixin):
 
         items never seen are dropped out
 
-
         Examples
         --------
         >>> from skmine.itemsets import SLIM

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -140,7 +140,6 @@ class SLIM(BaseEstimator, TransformerMixin):
 
     def _more_tags(self):  # tags for sklearn check_estimators)
         return {
-            "non_deterministic": True,  # default
             "no_validation": True,
             "preserves_dtype": False,
         }

--- a/skmine/itemsets/slim.py
+++ b/skmine/itemsets/slim.py
@@ -185,7 +185,7 @@ class SLIM(BaseEstimator, TransformerMixin):
         self._validate_data(X, force_all_finite=False, accept_sparse=False, ensure_2d=False,
                             ensure_min_samples=1, dtype=list)
         self.n_features_in_ = X.shape[-1] if not isinstance(X, list) else len(X[-1])
-        # TODO : significant for one-hot D ,not for list of itemset
+        # TODO : significant for one-hot D, not for list of itemset
         start = time.time()
         self.prefit(X, y=y)
         while True:

--- a/skmine/itemsets/tests/test_lcm.py
+++ b/skmine/itemsets/tests/test_lcm.py
@@ -54,9 +54,9 @@ true_patterns.loc[:, "itemset"] = true_patterns.itemset.map(set)
 NULL_RESULT = (None, None, 0)
 
 
-def test_lcm_fit():
+def test_lcm_fit_transform():
     lcm = LCM(min_supp=3)
-    lcm.fit(D)
+    lcm.fit_transform(D)
 
     for item in lcm.item_to_tids_.keys():
         assert set(lcm.item_to_tids_[item]) == truer_reorderfreq_item_to_tids[item]
@@ -64,7 +64,7 @@ def test_lcm_fit():
 
 def test_first_parent_limit_1():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     limit = 1
     tids = lcm.item_to_tids_[limit]
@@ -82,7 +82,7 @@ def test_first_parent_limit_1():
 
 def test_first_parent_limit_2():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     # pattern = [] -> first parent OK
     tids = lcm.item_to_tids_[2]
@@ -100,7 +100,7 @@ def test_first_parent_limit_2():
 
 def test_first_parent_limit_3():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     tids = lcm.item_to_tids_[3]
     itemset, _, tids = next(lcm._inner((frozenset(), tids), 3), NULL_RESULT)
@@ -111,7 +111,7 @@ def test_first_parent_limit_3():
 
 def test_first_parent_limit_4():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     tids = lcm.item_to_tids_[4]
     itemset, _, tids = next(lcm._inner((frozenset(), tids), 4), NULL_RESULT)
@@ -122,7 +122,7 @@ def test_first_parent_limit_4():
 
 def test_first_parent_limit_5():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     tids = lcm.item_to_tids_[5]
     itemset, _, tids = next(lcm._inner((frozenset(), tids), 5), NULL_RESULT)
@@ -133,7 +133,7 @@ def test_first_parent_limit_5():
 
 def test_first_parent_limit_6():
     lcm = LCM(min_supp=3)
-    lcm.fit(D, return_tids=True)
+    lcm.fit_transform(D, return_tids=True)
 
     tids = lcm.item_to_tids_[1]
     itemset, _, tids = next(lcm._inner((frozenset(), tids), 1), NULL_RESULT)
@@ -142,7 +142,7 @@ def test_first_parent_limit_6():
     assert len(tids) == 5
 
 
-def test_lcm_empty_fit():
+def test_lcm_empty_fit_transform():
     # 1. test with a min_supp high above the maximum supp
     lcm = LCM(min_supp=100)
     res = lcm.fit_transform(D)
@@ -169,7 +169,7 @@ def test_lcm_discover():
 
 def test_relative_support():
     lcm = LCM(min_supp=0.4)  # 40% out of 7 transactions ~= 3
-    lcm.fit(D)
+    lcm.fit_transform(D)
     np.testing.assert_almost_equal(lcm.min_supp_, 2.8, 2)
 
     for item in lcm.item_to_tids_.keys():
@@ -212,12 +212,6 @@ def test_lcm_max():
 
 
 def test_lcm_lexicographic_order():
-    db = [
-        [0, 1, 2, 3],
-        [0, 1, 2],
-        [0, 1],
-        [0]
-    ]
     lcm = LCM(min_supp=3)
     patterns = lcm.fit_transform(D, lexicographic_order=False)
     longest_itemset = max(patterns.itemset, key=len)


### PR DESCRIPTION
This PR aims to:

- **Run tests on different versions of Python**, including the latest (**3.x, 3.10, 3.9, 3.8**) to avoid the risk of being aware of bugs late when new versions of Python are released or when a new module is used.

- SLIM and LCM **display parameters** (return_tids, lexicographic_order...) **have been put into the `transform` method** to return to a similar way of working to `discover`. The documentation has been put back in the right places.